### PR TITLE
Adding id_token to handleWindowCallback()

### DIFF
--- a/src/adal4.service.ts
+++ b/src/adal4.service.ts
@@ -157,7 +157,7 @@ export class Adal4Service {
               this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION)
                 , requestInfo.parameters['access_token']);
             }
-            if (requestInfo.parameters['id_token']) {
+            else if (requestInfo.parameters['id_token']) {
               this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION)
                 , requestInfo.parameters['id_token']);
             }

--- a/src/adal4.service.ts
+++ b/src/adal4.service.ts
@@ -157,6 +157,10 @@ export class Adal4Service {
               this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION)
                 , requestInfo.parameters['access_token']);
             }
+            if (requestInfo.parameters['id_token']) {
+              this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION)
+                , requestInfo.parameters['id_token']);
+            }
             else if (requestInfo.parameters['error']) {
               this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION), null);
               this.adalContext._renewFailed = true;


### PR DESCRIPTION
This fix is intended to fix a bug where the valid scenario of refreshing an `id_token` is not handled. This is mirrored in the adal.js library [here](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/dev/lib/adal.js), at line 1252:

`token = requestInfo.parameters[this.CONSTANTS.ACCESS_TOKEN] || requestInfo.parameters[this.CONSTANTS.ID_TOKEN]`