### PR TITLE
fix AdalInterceptor

### DIFF
--- a/adal.interceptor.ts
+++ b/adal.interceptor.ts
@@ -1,18 +1,27 @@
 import { Injectable, Injector } from '@angular/core';
-import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { AdalService } from './adal.service';
-
+import 'rxjs/add/operator/map';
 
 @Injectable()
 export class AdalInterceptor implements HttpInterceptor {
 
-    constructor(private adalService: AdalService) { }
+    constructor(private adal: AdalService) { }
 
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-
-        const authReq = req.clone({ headers: req.headers.set('Authorization', `Bearer ${this.adalService.userInfo.token}`) });
-
-        return next.handle(authReq);
+        const url = req.url;
+        const resource = this.adal.GetResourceForEndpoint(url);
+        if (resource && this.adal.userInfo.authenticated) {
+            let headers = req.headers || new HttpHeaders();
+            this.adal.acquireToken(resource)
+                .subscribe((token: string) => {
+                    headers = headers.append('Authorization', 'Bearer ' + token);
+                }
+            );
+            return next.handle(req.clone({ headers: headers }));        
+        } else {
+            return next.handle(req.clone());
+        }
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,42 +6,43 @@ var
     replace = require('gulp-replace'),
     fs = require('fs');
 
+// delete ./dist directory
 gulp.task('clean', function () {
     del(['./dist/*']);
 });
 
-gulp.task('copy', function (cb) {
-    gulp.src(['adal-angular.d.ts']).pipe(gulp.dest('./dist/'));
-});
-
-gulp.task('copy-package', function (cb) {
-
-    const pkgjson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-
-    delete pkgjson.scripts;
-
-    delete pkgjson.devDependencies;
-
-    const filepath = './dist/package.json';
-
-    fs.writeFileSync(filepath, JSON.stringify(pkgjson, null, 2), 'utf-8');
-});
-
-gulp.task('replace', function () {
-    gulp.src(['./dist/adal.service.d.ts'])
-        .pipe(replace('../adal-angular.d.ts', './adal-angular.d.ts'))
-        .pipe(gulp.dest('./dist'));
-});
-
-gulp.task('build', function (cb) {
-    exec('npm run build', function (err, stdout, stderr) {
+// execute npm compile script
+gulp.task('compile', ['clean'], function (cb) {
+    exec('npm run compile', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
         cb(err);
     });
 });
 
-gulp.task('bump', function () {
+// include package.json file in ./dist folder
+gulp.task('package', ['compile'], function () {
+    const pkgjson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    delete pkgjson.scripts;
+    delete pkgjson.devDependencies;
+    const filepath = './dist/package.json';
+    fs.writeFileSync(filepath, JSON.stringify(pkgjson, null, 2), 'utf-8');
+});
+
+// include type definition file for adal-angular
+gulp.task('copy', ['package'], function () {
+    gulp.src(['adal-angular.d.ts']).pipe(gulp.dest('./dist/'));
+})
+
+// rewrite type definition file path for adal-angular in adal.service.d.ts
+gulp.task('replace', ['copy'], function () {
+    gulp.src('./dist/adal.service.d.ts')
+    .pipe(replace('../adal-angular.d.ts', './adal-angular.d.ts'))
+    .pipe(gulp.dest('./dist/'))
+})
+
+// increase the version in package.json
+gulp.task('bump', ['replace'], function () {
     gulp.src('./package.json')
         .pipe(bump({
             type: 'patch'
@@ -49,7 +50,8 @@ gulp.task('bump', function () {
         .pipe(gulp.dest('./'));
 });
 
-gulp.task('git-add', function (cb) {
+// git add
+gulp.task('git-add', ['bump'], function (cb) {
     exec('git add -A', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
@@ -57,11 +59,9 @@ gulp.task('git-add', function (cb) {
     });
 });
 
-
-gulp.task('git-commit', function (cb) {
-
+// git commit
+gulp.task('git-commit', ['git-add'], function (cb) {
     var package = require('./package.json');
-
     exec('git commit -m "Version ' + package.version + ' release."', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
@@ -69,8 +69,8 @@ gulp.task('git-commit', function (cb) {
     });
 });
 
-gulp.task('git-push', function (cb) {
-
+// git push
+gulp.task('git-push', ['git-commit'], function (cb) {
     exec('git push', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
@@ -78,11 +78,14 @@ gulp.task('git-push', function (cb) {
     });
 });
 
-gulp.task('publish', function (cb) {
-
+// publish ./dist directory to npm
+gulp.task('publish', ['git-push'], function (cb) {
     exec('npm publish ./dist', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
         cb(err);
     });
 });
+
+// build ./dist folder - used for development
+gulp.task('default', ['replace'], function (cb) {});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,15 +4,17 @@ var
     exec = require('child_process').exec,
     gulp = require('gulp'),
     replace = require('gulp-replace'),
+    watch = require('gulp-watch'),
     fs = require('fs');
 
-// delete ./dist directory
+// delete content of ./dist directory
 gulp.task('clean', function () {
-    del(['./dist/*']);
+    del(['./dist/*', '!dist/index.js']);
 });
 
 // execute npm compile script
-gulp.task('compile', ['clean'], function (cb) {
+gulp.task('compile', function (cb) {
+//gulp.task('compile', ['clean'], function (cb) {
     exec('npm run compile', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
@@ -79,7 +81,7 @@ gulp.task('git-push', ['git-commit'], function (cb) {
 });
 
 // publish ./dist directory to npm
-gulp.task('publish', ['git-push'], function (cb) {
+gulp.task('publish', ['clean', 'git-push'], function (cb) {
     exec('npm publish ./dist', function (err, stdout, stderr) {
         console.log(stdout);
         console.log(stderr);
@@ -87,5 +89,12 @@ gulp.task('publish', ['git-push'], function (cb) {
     });
 });
 
-// build ./dist folder - used for development
-gulp.task('default', ['replace'], function (cb) {});
+// build ./dist folder
+gulp.task('default', ['replace'], function () {});
+
+// watch for changes and rebuild ./dist folder
+gulp.task('watch', ['default'], function (cb) {
+    return watch('*', function () {
+        gulp.start('default');
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -563,11 +563,36 @@
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
       "dev": true
     },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
     "clone-stats": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "process-nextick-args": "1.0.7",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2328,6 +2353,150 @@
         }
       }
     },
+    "gulp-watch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-5.0.0.tgz",
+      "integrity": "sha512-q+HLppxXd11z9ndqql4Z0sd5xOAesJjycl0PRaq6ImK7b1BqBRL37YvxEE8ngUdIfpfHa0O9OCoovoggcFpCaQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "chokidar": "2.0.2",
+        "glob-parent": "3.1.0",
+        "gulp-util": "3.0.8",
+        "object-assign": "4.1.1",
+        "path-is-absolute": "1.0.1",
+        "readable-stream": "2.3.5",
+        "slash": "1.0.0",
+        "vinyl": "2.1.0",
+        "vinyl-file": "2.0.0"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+          "dev": true,
+          "requires": {
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.0",
+            "fsevents": "1.1.3",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.4"
+          },
+          "dependencies": {
+            "anymatch": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+              "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+              "dev": true,
+              "requires": {
+                "micromatch": "3.1.5",
+                "normalize-path": "2.1.1"
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "vinyl": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+          "dev": true,
+          "requires": {
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
+          }
+        }
+      }
+    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -3342,6 +3511,12 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -3857,6 +4032,12 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
     "snapdragon": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
@@ -4170,6 +4351,66 @@
       "requires": {
         "first-chunk-stream": "1.0.0",
         "is-utf8": "0.2.1"
+      }
+    },
+    "strip-bom-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+      "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "first-chunk-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+          "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.5"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
       }
     },
     "strip-indent": {
@@ -4497,6 +4738,12 @@
         }
       }
     },
+    "upath": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+      "dev": true
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -4622,6 +4869,54 @@
         "clone": "1.0.3",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
+      }
+    },
+    "vinyl-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+      "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "dev": true,
+          "requires": {
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
       }
     },
     "vinyl-fs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adal-angular4",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -61,10 +61,16 @@
         "tslib": "1.9.0"
       }
     },
+    "@types/jasmine": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.6.tgz",
+      "integrity": "sha512-clg9raJTY0EOo5pVZKX3ZlMjlYzVU73L71q5OV1jhE2Uezb7oF94jh4CvwrW6wInquQAdhOxJz5VDF2TLUGmmA==",
+      "dev": true
+    },
     "adal-angular": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/adal-angular/-/adal-angular-1.0.16.tgz",
-      "integrity": "sha1-4rwxvHEqr/ugU6pN1GvITrXSCQ8="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/adal-angular/-/adal-angular-1.0.15.tgz",
+      "integrity": "sha1-8qnvgvNYxEToMUKs5l0yJ6RBBDs="
     },
     "ansi-cyan": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Angular 4+ ADAL Wrapper",
   "main": "index.js",
   "scripts": {
-    "clean": "gulp clean",
-    "compile": "node_modules/.bin/ngc -p tsconfig-aot.json",
-    "build": "npm run clean && npm run compile && gulp copy && gulp replace",
-    "publish": "npm run build && gulp bump && gulp copy-package && gulp git-add && gulp git-commit && gulp git-push && gulp publish"
+    "compile": "node_modules/.bin/ngc -p tsconfig-aot.json"
   },
   "repository": {
     "type": "git",
@@ -38,6 +35,7 @@
     "@angular/core": "^5.2.5",
     "@angular/platform-browser": "^5.2.5",
     "@angular/router": "^5.2.5",
+    "@types/jasmine": "^2.5.53",
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-bump": "^3.1.0",
@@ -49,6 +47,6 @@
     "zone.js": "^0.8.20"
   },
   "dependencies": {
-    "adal-angular": "^1.0.16"
+    "adal-angular": "=1.0.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp": "^3.9.1",
     "gulp-bump": "^3.1.0",
     "gulp-replace": "^0.6.1",
+    "gulp-watch": "^5.0.0",
     "rollup": "^0.56.0",
     "rxjs": "^5.5.6",
     "typescript": "^2.7.2",


### PR DESCRIPTION
The AdalInterceptor was not working correctly: it always injected the
wrong token to the HTTP request. Instead of just using the token stored
into `this.adalService.userInfo.token`, the interceptor should:

1. determine which endpoint the request is directed to (with respect
   to `environment.adalConfig.endpoints`
2. if the request is not directed to a registered endpoint, then it
   should pass the request to the next handler
3. if instead the request is directed to a registered endpoint, the
   interceptor should acquire the token for that specific endpoint
4. and inject it into the request before passing it to the next handler

Some improvements to the gulpfile have also been implemented.