### PR TITLE
fix adal.interceptor to correctly acquire token on first login

### DIFF
--- a/adal.interceptor.ts
+++ b/adal.interceptor.ts
@@ -18,15 +18,15 @@ export class AdalInterceptor implements HttpInterceptor {
             return next.handle(req.clone());
         }
 
+        // if the user is not authenticated then drop the request
+        if (!this.adal.userInfo.authenticated) {
+            throw new Error('Cannot send request to registered endpoint if the user is not authenticated.');
+        }
+
         // if the endpoint is registered then acquire and inject token
         let headers = req.headers || new HttpHeaders();
         return this.adal.acquireToken(resource)
             .mergeMap((token: string) => {
-                // if the user is not authenticated then drop the request
-                if (!this.adal.userInfo.authenticated) {
-                    throw new Error('Cannot send request to registered endpoint if the user is not authenticated.');
-                }
-
                 // inject the header
                 headers = headers.append('Authorization', 'Bearer ' + token);
                 return next.handle(req.clone({ headers: headers }));

--- a/adal.interceptor.ts
+++ b/adal.interceptor.ts
@@ -18,11 +18,11 @@ export class AdalInterceptor implements HttpInterceptor {
             return next.handle(req.clone());
         }
 
-        // is the endpoint is registered then acquire and inject token
+        // if the endpoint is registered then acquire and inject token
         let headers = req.headers || new HttpHeaders();
         return this.adal.acquireToken(resource)
             .mergeMap((token: string) => {
-                // is the user is not authenticated then drop the request
+                // if the user is not authenticated then drop the request
                 if (!this.adal.userInfo.authenticated) {
                     throw new Error('Cannot send request to registered endpoint if the user is not authenticated.');
                 }


### PR DESCRIPTION
AdalInterceptor was not working correctly if the user has no valid token for an endpoint (e.g. if the token expired).

The interceptor now fetches the token **before** passing the current HttpRequest to the next handler. 

Before this fix, the interceptor called `acquireToken()`, but did not wait to get the token before injecting the Authorization header.

Therefore, at first login the requests to registered endpoints returned a 401 Unauthorized.