### PR TITLE
fix(auth): replace username with userName

### DIFF
--- a/adal-angular.d.ts
+++ b/adal-angular.d.ts
@@ -44,7 +44,7 @@ declare namespace adal {
      * @interface User
      */
     interface User {
-        username: string;
+        userName: string;
         profile: any;
         authenticated: any;
         error: any;

--- a/adal.service.ts
+++ b/adal.service.ts
@@ -13,7 +13,7 @@ export class AdalService {
 
     private user: adal.User = {
         authenticated: false,
-        username: '',
+        userName: '',
         error: '',
         token: '',
         profile: {}
@@ -175,14 +175,14 @@ export class AdalService {
     private updateDataFromCache(resource: string): void {
         const token = this.context.getCachedToken(resource);
         this.user.authenticated = token !== null && token.length > 0;
-        const user = this.context.getCachedUser() || { username: '', profile: <any>undefined };
+        const user = this.context.getCachedUser() || { userName: '', profile: <any>undefined };
         if (user) {
-            this.user.username = user.username;
+            this.user.userName = user.userName;
             this.user.profile = user.profile;
             this.user.token = token;
             this.user.error = this.context.getLoginError();
         } else {
-            this.user.username = '';
+            this.user.userName = '';
             this.user.profile = {};
             this.user.token = '';
             this.user.error = '';


### PR DESCRIPTION
In `updateDataFromCache()` there's a call to `context.getCachedUser()` which returns a User object.
The code reads the `username`from the user, whereas it should read the `userName` (with a capital N).
To verify this see the [Azure AD JS](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/dev/lib/adal.js)