### PR TITLE
fix error with 'Cannot read property context of undefined

### DIFF
--- a/adal.service.ts
+++ b/adal.service.ts
@@ -138,10 +138,12 @@ export class AdalService {
     }
 
     public getUser(): Observable<any> {
+        const __this = this;   // save outer this for inner function
+
         return bindCallback((cb: any) => {
             this.context.getUser(function (error: string, user: any) {
                 if (error) {
-                    this.context.error('Error when getting user', error);
+                    __this.context.error('Error when getting user', error);
                     cb(null);
                 } else {
                     cb(user);

--- a/adal.service.ts
+++ b/adal.service.ts
@@ -141,7 +141,7 @@ export class AdalService {
         const __this = this;   // save outer this for inner function
 
         return bindCallback((cb: any) => {
-            this.context.getUser(function (error: string, user: any) {
+            __this.context.getUser(function (error: string, user: any) {
                 if (error) {
                     __this.context.error('Error when getting user', error);
                     cb(null);


### PR DESCRIPTION
If you look at other similar bits of code throughout the file, you will see the use of _this inside the callbacks. I guess it was missed in this case. It's causing me an error in my code on the following line...

(app.component.ts) OnInit
this.user$ = this.adalService.getUser();

This is called before the user is authenticated. In my code, I'm just setting up an observable that will push out the user when they eventually get authenticated.