### PR TITLE
fix: token renewal operation failed due to timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adal-angular4",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Angular 4+ ADAL Wrapper",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
     "zone.js": "0.8.26"
   },
   "dependencies": {
-    "adal-angular": "1.0.17",
+    "adal-angular": "=1.0.15",
     "npm": "6.0.0"
   }
 }


### PR DESCRIPTION
When requesting a token for an endpoint, the console errors with _ERROR Token renewal operation failed due to timeout_.
Resolved by downgrading to adal-angular 1.0.15.

See #47