### PR TITLE
Fix RxJS deprecated resultSelector and add stricter typings

### DIFF
--- a/adal.guard.ts
+++ b/adal.guard.ts
@@ -1,16 +1,24 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 import { AdalService } from './adal.service';
 
 @Injectable()
-export class AdalGuard implements CanActivate {
+export class AdalGuard implements CanActivate, CanActivateChild {
 
   constructor(private adalService: AdalService) { }
 
   canActivate(
-    next: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean> | Promise<boolean> | boolean {
     return this.adalService.userInfo.authenticated;
   }
+
+    public canActivateChild(
+        childRoute: ActivatedRouteSnapshot,
+        state: RouterStateSnapshot
+    ): Observable<boolean> | Promise<boolean> | boolean {
+        return this.canActivate(childRoute, state);
+    }
 }

--- a/adal.service.ts
+++ b/adal.service.ts
@@ -1,13 +1,14 @@
 /// <reference path="adal-angular.d.ts" />
 
 import { Injectable } from '@angular/core';
-import { Observable, bindCallback} from 'rxjs';
+import { Observable, bindCallback } from 'rxjs';
+import { map } from 'rxjs/operators';
 import * as lib from 'adal-angular';
 
 @Injectable()
 export class AdalService {
 
-    private context: adal.AuthenticationContext = <any>null;
+    private context: adal.AuthenticationContext = null as any;
 
     private user: adal.User = {
         authenticated: false,
@@ -19,7 +20,7 @@ export class AdalService {
 
     constructor() { }
 
-    public init(configOptions: adal.Config) {
+    public init(configOptions: adal.Config): void {
         if (!configOptions) {
             throw new Error('You must set config, when calling init.');
         }
@@ -41,7 +42,7 @@ export class AdalService {
         window.AuthenticationContext = this.context.constructor;
 
         // loginresource is used to set authenticated status
-        this.updateDataFromCache(<any>this.context.config.loginResource);
+        this.updateDataFromCache(this.context.config.loginResource as string);
     }
 
     public get config(): adal.Config {
@@ -70,7 +71,7 @@ export class AdalService {
             const requestInfo = this.context.getRequestInfo(hash);
             this.context.saveTokenFromHash(requestInfo);
             if (requestInfo.requestType === this.context.REQUEST_TYPE.LOGIN) {
-                this.updateDataFromCache(<any>this.context.config.loginResource);
+                this.updateDataFromCache(this.context.config.loginResource as string);
 
             } else if (requestInfo.requestType === this.context.REQUEST_TYPE.RENEW_TOKEN) {
                 this.context.callback = window.parent.callBackMappedToRenewStates[requestInfo.stateResponse];
@@ -105,46 +106,40 @@ export class AdalService {
         }
     }
 
-    public getCachedToken(resource: string): string {
+    public getCachedToken(resource: string): string | null {
         return this.context.getCachedToken(resource);
     }
 
-    public acquireToken(resource: string) {
-        const _this = this;   // save outer this for inner function
-
-        let errorMessage: string;
-        return bindCallback(acquireTokenInternal, function (token: string) {
-            if (!token && errorMessage) {
-                throw (errorMessage);
-            }
-            return token;
-        })();
-
-        function acquireTokenInternal(cb: any) {
-            let s: any = null;
-
-            _this.context.acquireToken(resource, (error: string, tokenOut: string) => {
+    public acquireToken(resource: string): Observable<string | null> {
+        return bindCallback<string | null, string | null>((callback) => {
+            this.context.acquireToken(resource, (error: string, tokenOut: string) => {
                 if (error) {
-                    _this.context.error('Error when acquiring token for resource: ' + resource, error);
-                    errorMessage = error;
-                    cb(<any>null);
+                    this.context.error('Error when acquiring token for resource: ' + resource, error);
+                    callback(null, error);
                 } else {
-                    cb(tokenOut);
-                    s = tokenOut;
+                    callback(tokenOut, null);
                 }
             });
-            return s;
-        }
+        })()
+            .pipe<string | null>(
+                map((result) => {
+                    if (!result[0] && result[1]) {
+                        throw (result[1]);
+                    }
+
+                    return result[0];
+                })
+            );
     }
 
-    public getUser(): Observable<any> {
-        return bindCallback((cb: any) => {
-            this.context.getUser(function (error: string, user: any) {
+    public getUser(): Observable<adal.User | null> {
+        return bindCallback<adal.User | null>((callback) => {
+            this.context.getUser( (error: string, user?: adal.User) => {
                 if (error) {
                     this.context.error('Error when getting user', error);
-                    cb(null);
+                    callback(null);
                 } else {
-                    cb(user);
+                    callback(user || null);
                 }
             });
         })();
@@ -166,18 +161,18 @@ export class AdalService {
         this.context.verbose(message);
     }
 
-    public GetResourceForEndpoint(url: string): string {
+    public getResourceForEndpoint(url: string): string | null {
         return this.context.getResourceForEndpoint(url);
     }
 
-    public refreshDataFromCache() {
-        this.updateDataFromCache(<any>this.context.config.loginResource);
+    public refreshDataFromCache(): void {
+        this.updateDataFromCache(this.context.config.loginResource as string);
     }
 
     private updateDataFromCache(resource: string): void {
         const token = this.context.getCachedToken(resource);
         this.user.authenticated = token !== null && token.length > 0;
-        const user = this.context.getCachedUser() || { userName: '', profile: <any>undefined };
+        const user = this.context.getCachedUser() || { userName: '', profile: undefined };
         if (user) {
             this.user.userName = user.userName;
             this.user.profile = user.profile;


### PR DESCRIPTION
Rewrote `AdalService.aquireToken()` in order to remove RxJS deprecation warning.
(this also resolves https://github.com/benbaran/adal-angular4/pull/52 )

Added more stricter typings and also added missing typings from `adal.AuthenticationContext` (e.g. `getCachedToken` can return `null` even if the typings say otherwise).

Added `CanActivateChild` to `AdalGuard` for the sake of completeness.