### PR TITLE
Fix token refresh

### DIFF
--- a/adal-angular.d.ts
+++ b/adal-angular.d.ts
@@ -49,6 +49,7 @@ declare namespace adal {
         authenticated: any;
         error: any;
         token: any;
+        loginCached: boolean;
     }
 
     /**


### PR DESCRIPTION
Right now there is no automatic renewal of the login token which will make adal-angular4/adal.js think you aren't authenticated when you still have a valid login session. To fix this I've added a refresh that does two things:
1) If the login token has expired during init of adal-angular4 then it will refresh the login token and then reload the page. I don't like the reload but it was required for the new token to take affect.
2) As long as there is a valid token there is now a background timer that silently renews the token before it expires.