### PR TITLE
Added removeHash prarm to handleWindowCallback.  Updated typings.

### DIFF
--- a/adal-angular.d.ts
+++ b/adal-angular.d.ts
@@ -220,8 +220,9 @@ declare namespace adal {
          * Handles redirection after login operation. 
          * Gets access token from url and saves token to the (local/session) storage
          * or saves error in case unsuccessful login.
+         * @param {boolean} removeHash - Set to false if you use HashLocationStrategy to retain URL after refresh
          */
-        handleWindowCallback(): void;
+        handleWindowCallback(removeHash: boolean): void;
 
         log(level: number, message: string, error: any): void;
         error(message: string, error: any): void;

--- a/adal.service.ts
+++ b/adal.service.ts
@@ -79,7 +79,7 @@ export class AdalService {
         this.context.logOut();
     }
 
-    public handleWindowCallback(): void {
+    public handleWindowCallback(removeHash: boolean = true): void {
         const hash = window.location.hash;
         if (this.context.isCallback(hash)) {
             const requestInfo = this.context.getRequestInfo(hash);
@@ -111,11 +111,13 @@ export class AdalService {
         }
 
         // Remove hash from url
-        if (window.location.hash) {
-            if (window.history.replaceState) {
-                window.history.replaceState('', '/', window.location.pathname)
-            } else {
-                window.location.hash = '';
+        if (removeHash) {
+            if (window.location.hash) {
+                if (window.history.replaceState) {
+                    window.history.replaceState('', '/', window.location.pathname)
+                } else {
+                    window.location.hash = '';
+                }
             }
         }
     }


### PR DESCRIPTION
This change is to allow those that use Angular's Hash Location Strategy to not be redirected back to the root of the app on every refresh.  This is a non-breaking change as the default functionality did not change.