### PR TITLE
Fixing access token call back issue

### DIFF
--- a/adal.service.ts
+++ b/adal.service.ts
@@ -44,6 +44,11 @@ export class AdalService {
 
         // create instance with given config
         this.context = lib.inject(configOptions);
+        
+        // to keep sync with patent context if we are in in iframe 
+        if (window.parent && (window as any).parent._adalInstance) {
+          this.context = (window as any).parent._adalInstance;
+        }
 
         window.AuthenticationContext = this.context.constructor;
 


### PR DESCRIPTION
when trying to access resources, call back not function probably since the context have been initial fresh and do not have all callbacks pushed in to _callBackMappedToRenewStates and callback objects array. so we need to keep sync with parent context if we are in iframe