### PR TITLE
Add additional configurable property for adal.js

### DIFF
--- a/adal-angular.d.ts
+++ b/adal-angular.d.ts
@@ -37,6 +37,7 @@ declare namespace adal {
         extraQueryParameter?: string;
         navigateToLoginRequestUrl?: boolean;
         logOutUri?: string;
+        loadFrameTimeout?: number;
     }
 
     /**


### PR DESCRIPTION
V1.0.17 of adal-angular has additional property for `loadFrameTimeout` to change it from the default `6000 ms`