### PR TITLE
Cross-domain iframe fix

### DIFF
--- a/adal.service.ts
+++ b/adal.service.ts
@@ -83,9 +83,14 @@ export class AdalService {
             if (this.context._openedWindows.length > 0 && this.context._openedWindows[this.context._openedWindows.length - 1].opener && this.context._openedWindows[this.context._openedWindows.length - 1].opener._adalInstance) {
                 this.context = this.context._openedWindows[this.context._openedWindows.length - 1].opener._adalInstance;
                 isPopup = true;
-            }
-            else if (window.parent && window.parent._adalInstance) {
-                this.context = window.parent._adalInstance;
+            } else {
+                try {
+                    if (window.parent && window.parent._adalInstance) {
+                        this.context = window.parent._adalInstance;
+                    }
+                } catch {
+                    // ignore any exceptions and resort to default context.
+                }
             }
 
             const requestInfo = this.context.getRequestInfo(hash);


### PR DESCRIPTION
If the app is being hosted inside an iframe that is cross-domain, a "permission denied" exception will occur due to the **window.parent** check in adal.service's handleWindowCallback()

This is a small fix to just ignore the exception that occurs and resort to the current auth context.  This allows folks to host their app inside an iframe and still have adal sso work.