### PR TITLE
Turn off HttpInterceptor when Adal not initialized

### DIFF
--- a/adal.service.ts
+++ b/adal.service.ts
@@ -184,7 +184,9 @@ export class AdalService {
     }
 
     public getResourceForEndpoint(url: string): string | null {
-        return this.context.getResourceForEndpoint(url);
+        return this.context
+            ? null 
+            : this.context.getResourceForEndpoint(url);
     }
 
 


### PR DESCRIPTION
**Problem** When AdalService is not [initialized](https://github.com/benbaran/adal-angular4/blob/master/adal.service.ts#L29), AdalInterceptor crashes, thus preventing **all** http requests from succeeding - even if `skip-adal` header is available. It happens because [context is null](https://github.com/benbaran/adal-angular4/blob/master/adal.service.ts#L187) when AdalInterceptor gets [resource for endpoint](https://github.com/benbaran/adal-angular4/blob/master/adal.interceptor.ts#L18), before `skip-adal` header is checked. 

Two of possible fixes are: checking `skip-adal` header first or skipping `AdalInterceptor` when `AdalService` isn't initialized. I went with the latter, since it makes more sense for me :wink:
