### PR TITLE
Reload user data from cache when get RENEW_TOKEN request result

### DIFF
--- a/adal.service.ts
+++ b/adal.service.ts
@@ -95,7 +95,9 @@ export class AdalService {
             if (requestInfo.requestType === this.context.REQUEST_TYPE.LOGIN) {
                 this.updateDataFromCache();
                 this.setupLoginTokenRefreshTimer();
-            } 
+            } else if (requestInfo.requestType === this.context.REQUEST_TYPE.RENEW_TOKEN) {
+                this.updateDataFromCache();
+            }
 
             if (requestInfo.stateMatch) {
                 if (typeof callback === 'function') {


### PR DESCRIPTION
fix #124 
When RENEW_TOKEN request returns, need call `updateDataFromCache` to set user's data, especially the `authenticated` field.
If `authenticated` field don't set, will lead a unexpected `login()` call in 'adalIdTokenFrame' iframe, which will refresh the main page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/benbaran/adal-angular4/145)
<!-- Reviewable:end -->
